### PR TITLE
Expand the options that can be set, timeout critical urgency notification.

### DIFF
--- a/example.py
+++ b/example.py
@@ -5,8 +5,9 @@ import unotify
 
 unotify.notify(
     title = 'Testing',
-    description = 'uNotify example.',
+    message = 'uNotify example.',
     urgency = unotify.urgencies.NORMAL,
     timeout = 10,
-    icon = 'edit-undo'
+    app_name = 'Testing',
+    app_icon = 'edit-undo'
 )

--- a/unotify/core.py
+++ b/unotify/core.py
@@ -1,4 +1,5 @@
-import subprocess
+from subprocess import call, getstatusoutput
+from threading import Timer
 from . import urgencies
 
 BASE_COMMAND = "notify-send"
@@ -19,21 +20,60 @@ def _get_urgency(number: int) -> str:
     except Exception:
         return URGENCIES[2]
 
+def _close_notification(number: int):
+    call(['dbus-send',
+        '--type=method_call',
+        '--dest=org.freedesktop.Notifications',
+        '/org/freedesktop/Notifications',
+        'org.freedesktop.Notifications.CloseNotification',
+        'uint32:{}'.format(number)])
+
 def notify(
     title: str,
-    description: str,
+    message: str,
+    app_name: str = None,
+    app_icon: str = None,
+    hint: str = None,
+    category: str = None,
     urgency: int = None,
-    icon: str = None,
-    timeout: str = None,
+    replaceid: int = None,
+    timeout: int = None,
+    returnid: bool = False,
+    transient: bool = False,
 ):
     if not urgency:
         urgency = urgencies.NORMAL
-    _urgency = _get_urgency(urgency)
-    title = _remove_illegal_chars(title)
-    description = _remove_illegal_chars(description)
-    COMMAND = f'{BASE_COMMAND} "{title}" "{description}" -u {_urgency} '
-    if icon:
-        COMMAND += f"-i {icon} "
+
+    COMMAND = f'{BASE_COMMAND}\
+        "{_remove_illegal_chars(title)}"\
+        "{_remove_illegal_chars(message)}"\
+        -u {_get_urgency(urgency)} -p'
+
+    if app_name:
+        COMMAND += f" -a {_remove_illegal_chars(app_name)}"
+    if app_icon:
+        COMMAND += f" -i {app_icon}"
+    if category:
+        COMMAND += f" -c {category}"
+    if hint:
+        COMMAND += f" -h {_remove_illegal_chars(hint)}"
+    if replaceid:
+        COMMAND += f" -r {replaceid}"
     if timeout:
-        COMMAND += f"-t {timeout} "
-    return subprocess.call(COMMAND, shell=True)
+        COMMAND += f" -t {timeout*1000}"
+    if transient:
+        COMMAND += f" -e"
+
+    status, output = getstatusoutput(COMMAND)
+    if status != 0:
+        raise Exception(output)
+    else:
+        notifyid = int(output)
+
+    if urgency == urgencies.HIGH and timeout:
+        Timer(timeout, _close_notification, args=[notifyid]).start()
+   
+    if returnid:
+        return notifyid
+    else:
+        return True


### PR DESCRIPTION
- add ability to timeout critical urgency notification.
- add ability to return `notifyid`
- add ability to set `--app-name` `--icon=` `--category` `--transient` `--hint` `--replace-id`
- unify with part `plyer.notification` interface.